### PR TITLE
Update s3tools/s3cmd repo URL

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,7 @@ directory "#{node[:s3cmd][:install_prefix_root]}/share/s3cmd" do
 end
 
 git "#{node[:s3cmd][:install_prefix_root]}/share/s3cmd" do
-  repository "git://github.com/s3tools/s3cmd.git"
+  repository "https://github.com/s3tools/s3cmd.git"
   reference node[:s3cmd][:version]
   action :sync
 end


### PR DESCRIPTION
Due to this `https://github.blog/2021-09-01-improving-git-protocol-security-github/`, some sort of secure URL must be used to access GitHub repositories.